### PR TITLE
Math improvements

### DIFF
--- a/convert.h
+++ b/convert.h
@@ -22,9 +22,10 @@
 
 struct converter_state;
 typedef enum { INPUT_UC8=0, INPUT_SC16, INPUT_SC16Q11 } input_format_t;
+typedef float mag_data_t;
 
 typedef void (*iq_convert_fn)(void *iq_data,
-                              uint16_t *mag_data,
+                              mag_data_t *mag_data,
                               unsigned nsamples,
                               struct converter_state *state,
                               double *out_mean_level,

--- a/demod_2400.c
+++ b/demod_2400.c
@@ -74,13 +74,13 @@ void demodulate2400(struct mag_buf *mag)
     const mag_data_t *const m = mag->data;
     const uint32_t mlen = mag->length;
 
-    double sum_signal_power = 0.0;
+    internal_float_t sum_signal_power = 0.0;
 
     msg = msg1;
 
     for (uint32_t j = 0; j < mlen; j++) {
         const mag_data_t *preamble = &m[j];
-        double high, base_signal, base_noise;
+        internal_float_t high, base_signal, base_noise;
         int try_phase;
         int msglen;
 
@@ -329,7 +329,7 @@ void demodulate2400(struct mag_buf *mag)
 
         // measure signal power
         {
-            double signal_power = 0.0;
+            internal_float_t signal_power = 0.0;
             int signal_len = msglen*12/5;
 
             for (int k = 0; k < signal_len; ++k) {
@@ -474,9 +474,9 @@ void demodulate2400AC(struct mag_buf *mag)
 
     memset(&mm, 0, sizeof(mm));
 
-    const double noise_stddev = sqrt(mag->mean_power - mag->mean_level * mag->mean_level); // Var(X) = E[(X-E[X])^2] = E[X^2] - (E[X])^2
-    const double noise_level = mag->mean_power + noise_stddev;
-    const double noise_level_plus_6dB = noise_level * 2.0;
+    const internal_float_t noise_stddev = sqrt(mag->mean_power - mag->mean_level * mag->mean_level); // Var(X) = E[(X-E[X])^2] = E[X^2] - (E[X])^2
+    const internal_float_t noise_level = mag->mean_power + noise_stddev;
+    const internal_float_t noise_level_plus_6dB = noise_level * 2.0;
 
     for (uint32_t f1_sample = 1; f1_sample < mlen; ++f1_sample) {
         // Mode A/C messages should match this bit sequence:
@@ -532,7 +532,7 @@ void demodulate2400AC(struct mag_buf *mag)
         if (m[f1_sample+2] > m[f1_sample+0] || m[f1_sample+2] > m[f1_sample+1])
             continue;      // quiet part of bit wasn't sufficiently quiet
 
-        const double f1_level = (m[f1_sample+0] + m[f1_sample+1]) * 0.5;
+        const internal_float_t f1_level = (m[f1_sample+0] + m[f1_sample+1]) * 0.5;
 
         if (noise_level_plus_6dB > f1_level) {
             // require 6dB above noise
@@ -542,9 +542,9 @@ void demodulate2400AC(struct mag_buf *mag)
         // estimate initial clock phase based on the amount of power
         // that ended up in the second sample
 
-        const double f1a_power = m[f1_sample] * m[f1_sample];
-        const double f1b_power = m[f1_sample+1] * m[f1_sample+1];
-        const double fraction = f1b_power / (f1a_power + f1b_power);
+        const internal_float_t f1a_power = m[f1_sample] * m[f1_sample];
+        const internal_float_t f1b_power = m[f1_sample+1] * m[f1_sample+1];
+        const internal_float_t fraction = f1b_power / (f1a_power + f1b_power);
         const long f1_clock = lround(cyclesPerSample * (f1_sample + fraction * fraction));
 
         // same again for F2
@@ -559,18 +559,18 @@ void demodulate2400AC(struct mag_buf *mag)
         if (m[f2_sample+2] > m[f2_sample+0] || m[f2_sample+2] > m[f2_sample+1])
             continue;      // quiet part of bit wasn't sufficiently quiet
 
-        double f2_level = (m[f2_sample+0] + m[f2_sample+1]) * 0.5;
+        internal_float_t f2_level = (m[f2_sample+0] + m[f2_sample+1]) * 0.5;
 
         if (noise_level_plus_6dB > f2_level) {
             // require 6dB above noise
             continue;
         }
 
-        const double f1f2_level = (f1_level > f2_level ? f1_level : f2_level);
+        const internal_float_t f1f2_level = (f1_level > f2_level ? f1_level : f2_level);
 
-        const double midpoint = sqrt(noise_level * f1f2_level); // geometric mean of the two levels
-        const double signal_threshold = midpoint * M_SQRT2; // +3dB
-        const double noise_threshold = midpoint * M_SQRT1_2;  // -3dB
+        const internal_float_t midpoint = sqrt(noise_level * f1f2_level); // geometric mean of the two levels
+        const internal_float_t signal_threshold = midpoint * M_SQRT2; // +3dB
+        const internal_float_t noise_threshold = midpoint * M_SQRT1_2;  // -3dB
 
         // Looks like a real signal. Demodulate all the bits.
         long uncertain_bits = 0;

--- a/demod_2400.c
+++ b/demod_2400.c
@@ -42,20 +42,20 @@
 // nb: the correlation functions sum to zero, so we do not need to adjust for the DC offset in the input signal
 // (adding any constant value to all of m[0..3] does not change the result)
 
-static inline int slice_phase0(uint16_t *m) {
-    return 5 * m[0] - 3 * m[1] - 2 * m[2];
+static inline bool slice_phase0(const mag_data_t *const m) {
+    return (5.0 * m[0] - 3.0 * m[1] - 2.0 * m[2]) > 0.0;
 }
-static inline int slice_phase1(uint16_t *m) {
-    return 4 * m[0] - m[1] - 3 * m[2];
+static inline bool slice_phase1(const mag_data_t *const m) {
+    return (4.0 * m[0] - m[1] - 3.0 * m[2]) > 0.0;
 }
-static inline int slice_phase2(uint16_t *m) {
-    return 3 * m[0] + m[1] - 4 * m[2];
+static inline bool slice_phase2(const mag_data_t *const m) {
+    return (3.0 * m[0] + m[1] - 4.0 * m[2]) > 0.0;
 }
-static inline int slice_phase3(uint16_t *m) {
-    return 2 * m[0] + 3 * m[1] - 5 * m[2];
+static inline bool slice_phase3(const mag_data_t *const m) {
+    return (2.0 * m[0] + 3.0 * m[1] - 5.0 * m[2]) > 0.0;
 }
-static inline int slice_phase4(uint16_t *m) {
-    return m[0] + 5 * m[1] - 5 * m[2] - m[3];
+static inline bool slice_phase4(const mag_data_t *const m) {
+    return (m[0] + 5.0 * m[1] - 5.0 * m[2] - m[3]) > 0.0;
 }
 
 //
@@ -67,22 +67,20 @@ void demodulate2400(struct mag_buf *mag)
     static struct modesMessage zeroMessage;
     struct modesMessage mm;
     uint8_t msg1[MODES_LONG_MSG_BYTES], msg2[MODES_LONG_MSG_BYTES], *msg;
-    uint32_t j;
 
     uint8_t *bestmsg;
     int bestscore, bestphase;
 
-    uint16_t *m = mag->data;
-    uint32_t mlen = mag->length;
+    const mag_data_t *const m = mag->data;
+    const uint32_t mlen = mag->length;
 
-    uint64_t sum_scaled_signal_power = 0;
+    double sum_signal_power = 0.0;
 
     msg = msg1;
 
-    for (j = 0; j < mlen; j++) {
-        uint16_t *preamble = &m[j];
-        int high;
-        uint32_t base_signal, base_noise;
+    for (uint32_t j = 0; j < mlen; j++) {
+        const mag_data_t *preamble = &m[j];
+        double high, base_signal, base_noise;
         int try_phase;
         int msglen;
 
@@ -149,7 +147,7 @@ void demodulate2400(struct mag_buf *mag)
         }
 
         // Check for enough signal
-        if (base_signal * 2 < 3 * base_noise) // about 3.5dB SNR
+        if (base_signal * 2.0 < 3.0 * base_noise) // about 3.5dB SNR
             continue;
 
         // Check that the "quiet" bits 6,7,15,16,17 are actually quiet
@@ -169,7 +167,7 @@ void demodulate2400(struct mag_buf *mag)
         Modes.stats_current.demod_preambles++;
         bestmsg = NULL; bestscore = -2; bestphase = -1;
         for (try_phase = 4; try_phase <= 8; ++try_phase) {
-            uint16_t *pPtr;
+            const mag_data_t *pPtr;
             int phase, i, score, bytelen;
 
             // Decode all the next 112 bits, regardless of the actual message
@@ -185,14 +183,14 @@ void demodulate2400(struct mag_buf *mag)
                 switch (phase) {
                 case 0:
                     theByte =
-                        (slice_phase0(pPtr) > 0 ? 0x80 : 0) |
-                        (slice_phase2(pPtr+2) > 0 ? 0x40 : 0) |
-                        (slice_phase4(pPtr+4) > 0 ? 0x20 : 0) |
-                        (slice_phase1(pPtr+7) > 0 ? 0x10 : 0) |
-                        (slice_phase3(pPtr+9) > 0 ? 0x08 : 0) |
-                        (slice_phase0(pPtr+12) > 0 ? 0x04 : 0) |
-                        (slice_phase2(pPtr+14) > 0 ? 0x02 : 0) |
-                        (slice_phase4(pPtr+16) > 0 ? 0x01 : 0);
+                        (slice_phase0(pPtr) ? 0x80 : 0) |
+                        (slice_phase2(pPtr+2) ? 0x40 : 0) |
+                        (slice_phase4(pPtr+4) ? 0x20 : 0) |
+                        (slice_phase1(pPtr+7) ? 0x10 : 0) |
+                        (slice_phase3(pPtr+9) ? 0x08 : 0) |
+                        (slice_phase0(pPtr+12) ? 0x04 : 0) |
+                        (slice_phase2(pPtr+14) ? 0x02 : 0) |
+                        (slice_phase4(pPtr+16) ? 0x01 : 0);
 
 
                     phase = 1;
@@ -201,14 +199,14 @@ void demodulate2400(struct mag_buf *mag)
 
                 case 1:
                     theByte =
-                        (slice_phase1(pPtr) > 0 ? 0x80 : 0) |
-                        (slice_phase3(pPtr+2) > 0 ? 0x40 : 0) |
-                        (slice_phase0(pPtr+5) > 0 ? 0x20 : 0) |
-                        (slice_phase2(pPtr+7) > 0 ? 0x10 : 0) |
-                        (slice_phase4(pPtr+9) > 0 ? 0x08 : 0) |
-                        (slice_phase1(pPtr+12) > 0 ? 0x04 : 0) |
-                        (slice_phase3(pPtr+14) > 0 ? 0x02 : 0) |
-                        (slice_phase0(pPtr+17) > 0 ? 0x01 : 0);
+                        (slice_phase1(pPtr) ? 0x80 : 0) |
+                        (slice_phase3(pPtr+2) ? 0x40 : 0) |
+                        (slice_phase0(pPtr+5) ? 0x20 : 0) |
+                        (slice_phase2(pPtr+7) ? 0x10 : 0) |
+                        (slice_phase4(pPtr+9) ? 0x08 : 0) |
+                        (slice_phase1(pPtr+12) ? 0x04 : 0) |
+                        (slice_phase3(pPtr+14) ? 0x02 : 0) |
+                        (slice_phase0(pPtr+17) ? 0x01 : 0);
 
                     phase = 2;
                     pPtr += 19;
@@ -216,14 +214,14 @@ void demodulate2400(struct mag_buf *mag)
 
                 case 2:
                     theByte =
-                        (slice_phase2(pPtr) > 0 ? 0x80 : 0) |
-                        (slice_phase4(pPtr+2) > 0 ? 0x40 : 0) |
-                        (slice_phase1(pPtr+5) > 0 ? 0x20 : 0) |
-                        (slice_phase3(pPtr+7) > 0 ? 0x10 : 0) |
-                        (slice_phase0(pPtr+10) > 0 ? 0x08 : 0) |
-                        (slice_phase2(pPtr+12) > 0 ? 0x04 : 0) |
-                        (slice_phase4(pPtr+14) > 0 ? 0x02 : 0) |
-                        (slice_phase1(pPtr+17) > 0 ? 0x01 : 0);
+                        (slice_phase2(pPtr) ? 0x80 : 0) |
+                        (slice_phase4(pPtr+2) ? 0x40 : 0) |
+                        (slice_phase1(pPtr+5) ? 0x20 : 0) |
+                        (slice_phase3(pPtr+7) ? 0x10 : 0) |
+                        (slice_phase0(pPtr+10) ? 0x08 : 0) |
+                        (slice_phase2(pPtr+12) ? 0x04 : 0) |
+                        (slice_phase4(pPtr+14) ? 0x02 : 0) |
+                        (slice_phase1(pPtr+17) ? 0x01 : 0);
 
                     phase = 3;
                     pPtr += 19;
@@ -231,14 +229,14 @@ void demodulate2400(struct mag_buf *mag)
 
                 case 3:
                     theByte =
-                        (slice_phase3(pPtr) > 0 ? 0x80 : 0) |
-                        (slice_phase0(pPtr+3) > 0 ? 0x40 : 0) |
-                        (slice_phase2(pPtr+5) > 0 ? 0x20 : 0) |
-                        (slice_phase4(pPtr+7) > 0 ? 0x10 : 0) |
-                        (slice_phase1(pPtr+10) > 0 ? 0x08 : 0) |
-                        (slice_phase3(pPtr+12) > 0 ? 0x04 : 0) |
-                        (slice_phase0(pPtr+15) > 0 ? 0x02 : 0) |
-                        (slice_phase2(pPtr+17) > 0 ? 0x01 : 0);
+                        (slice_phase3(pPtr) ? 0x80 : 0) |
+                        (slice_phase0(pPtr+3) ? 0x40 : 0) |
+                        (slice_phase2(pPtr+5) ? 0x20 : 0) |
+                        (slice_phase4(pPtr+7) ? 0x10 : 0) |
+                        (slice_phase1(pPtr+10) ? 0x08 : 0) |
+                        (slice_phase3(pPtr+12) ? 0x04 : 0) |
+                        (slice_phase0(pPtr+15) ? 0x02 : 0) |
+                        (slice_phase2(pPtr+17) ? 0x01 : 0);
 
                     phase = 4;
                     pPtr += 19;
@@ -246,14 +244,14 @@ void demodulate2400(struct mag_buf *mag)
 
                 case 4:
                     theByte =
-                        (slice_phase4(pPtr) > 0 ? 0x80 : 0) |
-                        (slice_phase1(pPtr+3) > 0 ? 0x40 : 0) |
-                        (slice_phase3(pPtr+5) > 0 ? 0x20 : 0) |
-                        (slice_phase0(pPtr+8) > 0 ? 0x10 : 0) |
-                        (slice_phase2(pPtr+10) > 0 ? 0x08 : 0) |
-                        (slice_phase4(pPtr+12) > 0 ? 0x04 : 0) |
-                        (slice_phase1(pPtr+15) > 0 ? 0x02 : 0) |
-                        (slice_phase3(pPtr+17) > 0 ? 0x01 : 0);
+                        (slice_phase4(pPtr) ? 0x80 : 0) |
+                        (slice_phase1(pPtr+3) ? 0x40 : 0) |
+                        (slice_phase3(pPtr+5) ? 0x20 : 0) |
+                        (slice_phase0(pPtr+8) ? 0x10 : 0) |
+                        (slice_phase2(pPtr+10) ? 0x08 : 0) |
+                        (slice_phase4(pPtr+12) ? 0x04 : 0) |
+                        (slice_phase1(pPtr+15) ? 0x02 : 0) |
+                        (slice_phase3(pPtr+17) ? 0x01 : 0);
 
                     phase = 0;
                     pPtr += 20;
@@ -266,7 +264,7 @@ void demodulate2400(struct mag_buf *mag)
                     case 0: case 4: case 5: case 11:
                         bytelen = MODES_SHORT_MSG_BYTES; break;
 
-                    case 16: case 17: case 18: case 20: case 21: case 24:
+                    case 16: case 17: case 18: case 19: case 20: case 21: case 24:
                         break;
 
                     default:
@@ -331,21 +329,18 @@ void demodulate2400(struct mag_buf *mag)
 
         // measure signal power
         {
-            double signal_power;
-            uint64_t scaled_signal_power = 0;
+            double signal_power = 0.0;
             int signal_len = msglen*12/5;
-            int k;
 
-            for (k = 0; k < signal_len; ++k) {
-                uint32_t mag = m[j+19+k];
-                scaled_signal_power += mag * mag;
+            for (int k = 0; k < signal_len; ++k) {
+                const mag_data_t mag = m[j+19+k];
+                signal_power += mag * mag;
             }
 
-            signal_power = scaled_signal_power / 65535.0 / 65535.0;
             mm.signalLevel = signal_power / signal_len;
             Modes.stats_current.signal_power_sum += signal_power;
             Modes.stats_current.signal_power_count += signal_len;
-            sum_scaled_signal_power += scaled_signal_power;
+            sum_signal_power += signal_power;
 
             if (mm.signalLevel > Modes.stats_current.peak_signal_power)
                 Modes.stats_current.peak_signal_power = mm.signalLevel;
@@ -367,7 +362,6 @@ void demodulate2400(struct mag_buf *mag)
 
     /* update noise power */
     {
-        double sum_signal_power = sum_scaled_signal_power / 65535.0 / 65535.0;
         Modes.stats_current.noise_power_sum += (mag->mean_power * mag->length - sum_signal_power);
         Modes.stats_current.noise_power_count += mag->length;
     }
@@ -457,6 +451,13 @@ static void draw_modeac(uint16_t *m, unsigned modeac, unsigned f1_clock, unsigne
 ////////// MODE A/C
 //////////
 
+//static const double virtualClockFrequency = 60e6;
+//static const double virtualClockPeriod = 1.0 / virtualClockFrequency;
+//static const double bitClockFrequency = 12e6;
+//static const double bitClockPeriod = 1.0 / bitClockFrequency;
+static const int cyclesPerModeACBitPeriod = 87;
+static const int cyclesPerSample = 25;
+
 // Mode A/C bits are 1.45us wide, consisting of 0.45us on and 1.0us off
 // We track this in terms of a (virtual) 60MHz clock, which is the lowest common multiple
 // of the bit frequency and the 2.4MHz sampling frequency
@@ -465,20 +466,19 @@ static void draw_modeac(uint16_t *m, unsigned modeac, unsigned f1_clock, unsigne
 //            1.00us = 60 cycles } one bit period = 1.45us = 87 cycles
 //
 // one 2.4MHz sample = 25 cycles
-
 void demodulate2400AC(struct mag_buf *mag)
 {
     struct modesMessage mm;
-    uint16_t *m = mag->data;
-    uint32_t mlen = mag->length;
-    unsigned f1_sample;
+    const mag_data_t *const m = mag->data;
+    const uint32_t mlen = mag->length;
 
     memset(&mm, 0, sizeof(mm));
 
-    double noise_stddev = sqrt(mag->mean_power - mag->mean_level * mag->mean_level); // Var(X) = E[(X-E[X])^2] = E[X^2] - (E[X])^2
-    unsigned noise_level = (unsigned) ((mag->mean_power + noise_stddev) * 65535 + 0.5);
+    const double noise_stddev = sqrt(mag->mean_power - mag->mean_level * mag->mean_level); // Var(X) = E[(X-E[X])^2] = E[X^2] - (E[X])^2
+    const double noise_level = mag->mean_power + noise_stddev;
+    const double noise_level_plus_6dB = noise_level * 2.0;
 
-    for (f1_sample = 1; f1_sample < mlen; ++f1_sample) {
+    for (uint32_t f1_sample = 1; f1_sample < mlen; ++f1_sample) {
         // Mode A/C messages should match this bit sequence:
 
         // bit #     value
@@ -532,9 +532,9 @@ void demodulate2400AC(struct mag_buf *mag)
         if (m[f1_sample+2] > m[f1_sample+0] || m[f1_sample+2] > m[f1_sample+1])
             continue;      // quiet part of bit wasn't sufficiently quiet
 
-        unsigned f1_level = (m[f1_sample+0] + m[f1_sample+1]) / 2;
+        const double f1_level = (m[f1_sample+0] + m[f1_sample+1]) * 0.5;
 
-        if (noise_level * 2 > f1_level) {
+        if (noise_level_plus_6dB > f1_level) {
             // require 6dB above noise
             continue;
         }
@@ -542,15 +542,15 @@ void demodulate2400AC(struct mag_buf *mag)
         // estimate initial clock phase based on the amount of power
         // that ended up in the second sample
 
-        float f1a_power = (float)m[f1_sample] * m[f1_sample];
-        float f1b_power = (float)m[f1_sample+1] * m[f1_sample+1];
-        float fraction = f1b_power / (f1a_power + f1b_power);
-        unsigned f1_clock = (unsigned) (25 * (f1_sample + fraction * fraction) + 0.5);
+        const double f1a_power = m[f1_sample] * m[f1_sample];
+        const double f1b_power = m[f1_sample+1] * m[f1_sample+1];
+        const double fraction = f1b_power / (f1a_power + f1b_power);
+        const long f1_clock = lround(cyclesPerSample * (f1_sample + fraction * fraction));
 
         // same again for F2
         // F2 is 20.3us / 14 bit periods after F1
-        unsigned f2_clock = f1_clock + (87 * 14);
-        unsigned f2_sample = f2_clock / 25;
+        const long f2_clock = f1_clock + (cyclesPerModeACBitPeriod * 14L);
+        const long f2_sample = f2_clock / cyclesPerSample;
         assert(f2_sample < mlen + Modes.trailing_samples);
 
         if (!(m[f2_sample-1] < m[f2_sample+0]))
@@ -559,27 +559,26 @@ void demodulate2400AC(struct mag_buf *mag)
         if (m[f2_sample+2] > m[f2_sample+0] || m[f2_sample+2] > m[f2_sample+1])
             continue;      // quiet part of bit wasn't sufficiently quiet
 
-        unsigned f2_level = (m[f2_sample+0] + m[f2_sample+1]) / 2;
+        double f2_level = (m[f2_sample+0] + m[f2_sample+1]) * 0.5;
 
-        if (noise_level * 2 > f2_level) {
+        if (noise_level_plus_6dB > f2_level) {
             // require 6dB above noise
             continue;
         }
 
-        unsigned f1f2_level = (f1_level > f2_level ? f1_level : f2_level);
+        const double f1f2_level = (f1_level > f2_level ? f1_level : f2_level);
 
-        float midpoint = sqrtf(noise_level * f1f2_level); // geometric mean of the two levels
-        unsigned signal_threshold = (unsigned) (midpoint * M_SQRT2 + 0.5); // +3dB
-        unsigned noise_threshold = (unsigned) (midpoint / M_SQRT2 + 0.5);  // -3dB
+        const double midpoint = sqrt(noise_level * f1f2_level); // geometric mean of the two levels
+        const double signal_threshold = midpoint * M_SQRT2; // +3dB
+        const double noise_threshold = midpoint * M_SQRT1_2;  // -3dB
 
         // Looks like a real signal. Demodulate all the bits.
-        unsigned uncertain_bits = 0;
-        unsigned noisy_bits = 0;
-        unsigned bits = 0;
-        unsigned bit;
-        unsigned clock;
-        for (bit = 0, clock = f1_clock; bit < 20; ++bit, clock += 87) {
-            unsigned sample = clock / 25;
+        long uncertain_bits = 0;
+        long noisy_bits = 0;
+        long bits = 0;
+
+        for (long bit = 0, clock = f1_clock; bit < 20L; ++bit, clock += cyclesPerModeACBitPeriod) {
+            long sample = clock / cyclesPerSample;
 
             bits <<= 1;
             noisy_bits <<= 1;
@@ -650,7 +649,7 @@ void demodulate2400AC(struct mag_buf *mag)
         // Pass data to the next layer
         useModesMessage(&mm);
 
-        f1_sample += (20*87 / 25);
+        f1_sample += (20*cyclesPerModeACBitPeriod / cyclesPerSample);
         Modes.stats_current.demod_modeac++;
     }
 }

--- a/dump1090.c
+++ b/dump1090.c
@@ -176,13 +176,8 @@ void modesInit(void) {
     pthread_mutex_init(&Modes.data_mutex,NULL);
     pthread_cond_init(&Modes.data_cond,NULL);
 
-    // oops, demodulator doesn't support any other sample rate
-    //if (Modes.sample_rate < 2400000.0) {
-        Modes.sample_rate = 2400000.0;
-    //}
-
     // Allocate the various buffers used by Modes
-    Modes.trailing_samples = (MODES_PREAMBLE_US + MODES_LONG_MSG_BITS + 16) * 1e-6 * Modes.sample_rate;
+    Modes.trailing_samples = (MODES_PREAMBLE_US + MODES_LONG_MSG_BITS + 16) * 1e-6 * MODES_SAMPLE_RATE;
 
     if ( ((Modes.log10lut   = (uint16_t *) malloc(sizeof(uint16_t) * 256 * 256)                                 ) == NULL) )
     {
@@ -191,7 +186,7 @@ void modesInit(void) {
     }
 
     for (i = 0; i < MODES_MAG_BUFFERS; ++i) {
-        if ( (Modes.mag_buffers[i].data = calloc(MODES_MAG_BUF_SAMPLES+Modes.trailing_samples, sizeof(uint16_t))) == NULL ) {
+        if ( (Modes.mag_buffers[i].data = calloc(MODES_MAG_BUF_SAMPLES+Modes.trailing_samples, sizeof(mag_data_t))) == NULL ) {
             fprintf(stderr, "Out of memory allocating magnitude buffer.\n");
             exit(1);
         }

--- a/dump1090.h
+++ b/dump1090.h
@@ -273,6 +273,8 @@ typedef enum {
 #define MAX_AMPLITUDE 65535.0
 #define MAX_POWER (MAX_AMPLITUDE * MAX_AMPLITUDE)
 
+typedef double internal_float_t;
+
 // Include subheaders after all the #defines are in place
 
 #include "util.h"
@@ -299,8 +301,8 @@ struct mag_buf {
     uint64_t        sampleTimestamp; // Clock timestamp of the start of this block, 12MHz clock
     uint64_t        sysTimestamp;    // Estimated system time at start of block
     uint32_t        dropped;         // Number of dropped samples preceding this buffer
-    double          mean_level;      // Mean of normalized (0..1) signal level
-    double          mean_power;      // Mean of normalized (0..1) power level
+    internal_float_t mean_level;      // Mean of normalized (0..1) signal level
+    internal_float_t mean_power;      // Mean of normalized (0..1) power level
 };
 
 // Program global state

--- a/dump1090.h
+++ b/dump1090.h
@@ -54,7 +54,7 @@
 
 // Default version number, if not overriden by the Makefile
 #ifndef MODES_DUMP1090_VERSION
-# define MODES_DUMP1090_VERSION     "v1.13.3-paulyc"
+# define MODES_DUMP1090_VERSION     "v1.14-paulyc"
 #endif
 
 #ifndef MODES_DUMP1090_VARIANT
@@ -92,7 +92,7 @@
 
 // Default version number, if not overriden by the Makefile
 #ifndef MODES_DUMP1090_VERSION
-# define MODES_DUMP1090_VERSION     "v1.13-custom"
+# define MODES_DUMP1090_VERSION     "v1.14-custom"
 #endif
 
 #ifndef MODES_DUMP1090_VARIANT
@@ -100,6 +100,7 @@
 #endif
 
 #define HAVE_RTL_BIAST             1
+#define MODES_SAMPLE_RATE          2400000
 #define MODES_DEFAULT_PPM          0
 #define MODES_DEFAULT_FREQ         1090000000
 #define MODES_DEFAULT_WIDTH        1000
@@ -126,15 +127,15 @@
 #define MODES_SHORT_MSG_BITS    (MODES_SHORT_MSG_BYTES   * 8)
 #define MODES_LONG_MSG_SAMPLES  (MODES_LONG_MSG_BITS     * 2)
 #define MODES_SHORT_MSG_SAMPLES (MODES_SHORT_MSG_BITS    * 2)
-#define MODES_LONG_MSG_SIZE     (MODES_LONG_MSG_SAMPLES  * sizeof(uint16_t))
-#define MODES_SHORT_MSG_SIZE    (MODES_SHORT_MSG_SAMPLES * sizeof(uint16_t))
+//#define MODES_LONG_MSG_SIZE     (MODES_LONG_MSG_SAMPLES  * sizeof(uint16_t))
+//#define MODES_SHORT_MSG_SIZE    (MODES_SHORT_MSG_SAMPLES * sizeof(uint16_t))
 
 #define MODES_OS_PREAMBLE_SAMPLES  (20)
-#define MODES_OS_PREAMBLE_SIZE     (MODES_OS_PREAMBLE_SAMPLES  * sizeof(uint16_t))
+//#define MODES_OS_PREAMBLE_SIZE     (MODES_OS_PREAMBLE_SAMPLES  * sizeof(uint16_t))
 #define MODES_OS_LONG_MSG_SAMPLES  (268)
 #define MODES_OS_SHORT_MSG_SAMPLES (135)
-#define MODES_OS_LONG_MSG_SIZE     (MODES_LONG_MSG_SAMPLES  * sizeof(uint16_t))
-#define MODES_OS_SHORT_MSG_SIZE    (MODES_SHORT_MSG_SAMPLES * sizeof(uint16_t))
+//#define MODES_OS_LONG_MSG_SIZE     (MODES_LONG_MSG_SAMPLES  * sizeof(uint16_t))
+//#define MODES_OS_SHORT_MSG_SIZE    (MODES_SHORT_MSG_SAMPLES * sizeof(uint16_t))
 
 #define MODES_OUT_BUF_SIZE         (1500)
 #define MODES_OUT_FLUSH_SIZE       (MODES_OUT_BUF_SIZE - 256)
@@ -293,7 +294,7 @@ typedef enum {
 
 // Structure representing one magnitude buffer
 struct mag_buf {
-    uint16_t       *data;            // Magnitude data. Starts with Modes.trailing_samples worth of overlap from the previous block
+    mag_data_t       *data;            // Magnitude data. Starts with Modes.trailing_samples worth of overlap from the previous block
     unsigned        length;          // Number of valid samples _after_ overlap. Total buffer length is buf->length + Modes.trailing_samples.
     uint64_t        sampleTimestamp; // Clock timestamp of the start of this block, 12MHz clock
     uint64_t        sysTimestamp;    // Estimated system time at start of block
@@ -315,7 +316,7 @@ struct modes_t {                             // Internal state
     struct timespec reader_cpu_accumulator;               // CPU time used by the reader thread, copied out and reset by the main thread under the mutex
 
     unsigned        trailing_samples;                     // extra trailing samples in magnitude buffers
-    double          sample_rate;                          // actual sample rate in use (in hz)
+    //double          sample_rate;                          // actual sample rate in use (in hz)
 
     uint16_t       *log10lut;        // Magnitude -> log10 lookup table
     int             exit;            // Exit from the main loop when true

--- a/lib1090.c
+++ b/lib1090.c
@@ -105,7 +105,6 @@ static int __lib1090InitThread() {
     Modes.net_input_beast_ports = NULL;
     Modes.net_output_beast_ports = NULL;
     Modes.net_verbatim = 0;
-    //Modes.sample_rate = 4000000.0;
 
     modesInit();
     modesInitNet();
@@ -332,7 +331,7 @@ ssize_t lib1090FormatBeast(struct modesMessage *mm, uint8_t *beastBufferOut, siz
 int lib1090InitDump1090(struct dump1090Fork_t **forkInfoOut) {
     struct dump1090Fork_t *forkInfo = malloc(sizeof(struct dump1090Fork_t));
     memset(forkInfo, '\0', sizeof(struct dump1090Fork_t));
-    forkInfo->sample_rate = 2400000.0f;
+    forkInfo->sample_rate = 2.4e6;
     forkInfo->jsonDir = "/tmp/piaware";
     *forkInfoOut = forkInfo;
     return 0;

--- a/lib1090.h
+++ b/lib1090.h
@@ -361,6 +361,8 @@ typedef enum {
 #define MAX_AMPLITUDE 65535.0
 #define MAX_POWER (MAX_AMPLITUDE * MAX_AMPLITUDE)
 
+typedef double internal_float_t;
+
 // Include subheaders after all the #defines are in place
 #define DUMP1090_UTIL_H
 
@@ -543,15 +545,15 @@ struct stats {
     struct timespec background_cpu;
 
     // noise floor:
-    double noise_power_sum;
+    internal_float_t noise_power_sum;
     uint64_t noise_power_count;
 
     // mean signal power:
-    double signal_power_sum;
+    internal_float_t signal_power_sum;
     uint64_t signal_power_count;
 
     // peak signal power seen
-    double peak_signal_power;
+    internal_float_t peak_signal_power;
 
     // number of signals with power > -3dBFS
     uint32_t strong_signal_count;
@@ -685,8 +687,8 @@ struct mag_buf {
     uint64_t        sampleTimestamp; // Clock timestamp of the start of this block, 12MHz clock
     uint64_t        sysTimestamp;    // Estimated system time at start of block
     uint32_t        dropped;         // Number of dropped samples preceding this buffer
-    double          mean_level;      // Mean of normalized (0..1) signal level
-    double          mean_power;      // Mean of normalized (0..1) power level
+    internal_float_t mean_level;      // Mean of normalized (0..1) signal level
+    internal_float_t mean_power;      // Mean of normalized (0..1) power level
 };
 
 // Program global state

--- a/lib1090.h
+++ b/lib1090.h
@@ -63,7 +63,7 @@
 
 // Default version number, if not overriden by the Makefile
 #ifndef MODES_DUMP1090_VERSION
-# define MODES_DUMP1090_VERSION     "v1.13.3-paulyc"
+# define MODES_DUMP1090_VERSION     "v1.14-paulyc"
 #endif
 
 #ifndef MODES_DUMP1090_VARIANT
@@ -188,6 +188,7 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp);
 // ============================= #defines ===============================
 
 #define HAVE_RTL_BIAST             1
+#define MODES_SAMPLE_RATE          2400000
 #define MODES_DEFAULT_PPM          0
 #define MODES_DEFAULT_FREQ         1090000000
 #define MODES_DEFAULT_WIDTH        1000
@@ -218,11 +219,11 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp);
 #define MODES_SHORT_MSG_SIZE    (MODES_SHORT_MSG_SAMPLES * sizeof(uint16_t))
 
 #define MODES_OS_PREAMBLE_SAMPLES  (20)
-#define MODES_OS_PREAMBLE_SIZE     (MODES_OS_PREAMBLE_SAMPLES  * sizeof(uint16_t))
+//#define MODES_OS_PREAMBLE_SIZE     (MODES_OS_PREAMBLE_SAMPLES  * sizeof(uint16_t))
 #define MODES_OS_LONG_MSG_SAMPLES  (268)
 #define MODES_OS_SHORT_MSG_SAMPLES (135)
-#define MODES_OS_LONG_MSG_SIZE     (MODES_LONG_MSG_SAMPLES  * sizeof(uint16_t))
-#define MODES_OS_SHORT_MSG_SIZE    (MODES_SHORT_MSG_SAMPLES * sizeof(uint16_t))
+//#define MODES_OS_LONG_MSG_SIZE     (MODES_LONG_MSG_SAMPLES  * sizeof(uint16_t))
+//#define MODES_OS_SHORT_MSG_SIZE    (MODES_SHORT_MSG_SAMPLES * sizeof(uint16_t))
 
 #define MODES_OUT_BUF_SIZE         (1500)
 #define MODES_OUT_FLUSH_SIZE       (MODES_OUT_BUF_SIZE - 256)
@@ -644,9 +645,10 @@ void icaoFilterExpire();
 
 struct converter_state;
 typedef enum { INPUT_UC8=0, INPUT_SC16, INPUT_SC16Q11 } input_format_t;
+typedef float mag_data_t;
 
 typedef void (*iq_convert_fn)(void *iq_data,
-                              uint16_t *mag_data,
+                              mag_data_t *mag_data,
                               unsigned nsamples,
                               struct converter_state *state,
                               double *out_mean_level,
@@ -678,7 +680,7 @@ typedef enum {
 
 // Structure representing one magnitude buffer
 struct mag_buf {
-    uint16_t       *data;            // Magnitude data. Starts with Modes.trailing_samples worth of overlap from the previous block
+    mag_data_t      *data;            // Magnitude data. Starts with Modes.trailing_samples worth of overlap from the previous block
     unsigned        length;          // Number of valid samples _after_ overlap. Total buffer length is buf->length + Modes.trailing_samples.
     uint64_t        sampleTimestamp; // Clock timestamp of the start of this block, 12MHz clock
     uint64_t        sysTimestamp;    // Estimated system time at start of block
@@ -700,7 +702,7 @@ struct modes_t {                             // Internal state
     struct timespec reader_cpu_accumulator;               // CPU time used by the reader thread, copied out and reset by the main thread under the mutex
 
     unsigned        trailing_samples;                     // extra trailing samples in magnitude buffers
-    double          sample_rate;                          // actual sample rate in use (in hz)
+    //double          sample_rate;                          // actual sample rate in use (in hz)
 
     uint16_t       *log10lut;        // Magnitude -> log10 lookup table
     int             exit;            // Exit from the main loop when true
@@ -1388,7 +1390,7 @@ struct lib1090Config_t {
     const char *beastOutPipeName;
     int pipefd;
     pid_t childPid;
-    int sample_rate;
+    double sample_rate;
     const char *jsonDir;
 };
 
@@ -1411,7 +1413,7 @@ struct dump1090Fork_t {
     const char *userLon;
     int pipedes[2];
     pid_t childPid;
-    float sample_rate;
+    double sample_rate;
     const char *jsonDir;
     char scratch[128];
 };

--- a/sdr_bladerf.c
+++ b/sdr_bladerf.c
@@ -219,7 +219,7 @@ bool bladeRFOpen()
         goto error;
     }
 
-    if ((status = bladerf_set_sample_rate(BladeRF.device, BLADERF_MODULE_RX, Modes.sample_rate * BladeRF.decimation, NULL)) < 0) {
+    if ((status = bladerf_set_sample_rate(BladeRF.device, BLADERF_MODULE_RX, MODES_SAMPLE_RATE * BladeRF.decimation, NULL)) < 0) {
         fprintf(stderr, "bladerf_set_sample_rate failed: %s\n", bladerf_strerror(status));
         goto error;
     }
@@ -273,7 +273,7 @@ bool bladeRFOpen()
     show_config();
 
     BladeRF.converter = init_converter(INPUT_SC16Q11,
-                                       Modes.sample_rate,
+                                       MODES_SAMPLE_RATE,
                                        Modes.dc_filter,
                                        &BladeRF.converter_state);
     if (!BladeRF.converter) {
@@ -336,9 +336,9 @@ static void *handle_bladerf_samples(struct bladerf *dev,
 
     // Copy trailing data from last block (or reset if not valid)
     if (outbuf->dropped == 0) {
-        memcpy(outbuf->data, lastbuf->data + lastbuf->length, Modes.trailing_samples * sizeof(uint16_t));
+        memcpy(outbuf->data, lastbuf->data + lastbuf->length, Modes.trailing_samples * sizeof(mag_data_t));
     } else {
-        memset(outbuf->data, 0, Modes.trailing_samples * sizeof(uint16_t));
+        memset(outbuf->data, 0, Modes.trailing_samples * sizeof(mag_data_t));
     }
 
     // start handling metadata blocks
@@ -394,7 +394,7 @@ static void *handle_bladerf_samples(struct bladerf *dev,
 
         if (!blocks_processed) {
             // Compute the sample timestamp for the start of the block
-            outbuf->sampleTimestamp = nextTimestamp * 12e6 / Modes.sample_rate / BladeRF.decimation;
+            outbuf->sampleTimestamp = nextTimestamp * 12e6 / MODES_SAMPLE_RATE / BladeRF.decimation;
         }
 
         // Convert a block of data
@@ -412,7 +412,7 @@ static void *handle_bladerf_samples(struct bladerf *dev,
 
     if (blocks_processed) {
         // Get the approx system time for the start of this block
-        unsigned block_duration = 1e3 * outbuf->length / Modes.sample_rate;
+        unsigned block_duration = 1e3 * outbuf->length / MODES_SAMPLE_RATE;
         outbuf->sysTimestamp = entryTimestamp - block_duration;
 
         outbuf->mean_level /= blocks_processed;
@@ -462,7 +462,7 @@ void bladeRFRun()
         goto out;
     }
 
-    unsigned ms_per_transfer = 1000 * MODES_MAG_BUF_SAMPLES / Modes.sample_rate;
+    unsigned ms_per_transfer = 1000 * MODES_MAG_BUF_SAMPLES / MODES_SAMPLE_RATE;
     if ((status = bladerf_set_stream_timeout(BladeRF.device, BLADERF_MODULE_RX, ms_per_transfer * (transfers + 2))) < 0) {
         fprintf(stderr, "bladerf_set_stream_timeout() failed: %s\n", bladerf_strerror(status));
         goto out;

--- a/sdr_bladerf.c
+++ b/sdr_bladerf.c
@@ -338,13 +338,16 @@ static void *handle_bladerf_samples(struct bladerf *dev,
     if (outbuf->dropped == 0) {
         memcpy(outbuf->data, lastbuf->data + lastbuf->length, Modes.trailing_samples * sizeof(mag_data_t));
     } else {
-        memset(outbuf->data, 0, Modes.trailing_samples * sizeof(mag_data_t));
+        //memset(outbuf->data, 0, Modes.trailing_samples * sizeof(mag_data_t));
+        for (int i = 0; i < Modes.trailing_samples; ++i) {
+            outbuf->data[i] = 0.0;
+        }
     }
 
     // start handling metadata blocks
     outbuf->dropped = 0;
     outbuf->length = 0;
-    outbuf->mean_level = outbuf->mean_power = 0;
+    outbuf->mean_level = outbuf->mean_power = 0.0;
 
     unsigned blocks_processed = 0;
     unsigned samples_per_block = (BladeRF.block_size - 16) / 4;

--- a/sdr_ifile.c
+++ b/sdr_ifile.c
@@ -82,7 +82,7 @@ void ifileShowHelp()
     printf("--ifile <path>           read samples from given file ('-' for stdin)\n");
     printf("--iformat <type>         set sample format (UC8, SC16, SC16Q11)\n");
     printf("--throttle               process samples at the original capture speed\n");
-    //printf("--samplerate <rate>      original sample rate\n");
+    //printf("--oversample <rate>      oversampling multiple of 2.4 MHz\n");
     printf("\n");
 }
 
@@ -110,9 +110,6 @@ bool ifileHandleOption(int argc, char **argv, int *jptr)
         }
     } else if (!strcmp(argv[j],"--throttle")) {
         ifile.throttle = true;
-        // oops, demodulator doesnt support any sample rate but 2.4MHz, sigh
-    //} else if (!strcmp(argv[j],"--samplerate") && more) {
-    //    Modes.sample_rate = strtof(argv[++j], NULL);
     } else {
         return false;
     }
@@ -163,7 +160,7 @@ bool ifileOpen(void)
     }
 
     ifile.converter = init_converter(ifile.input_format,
-                                     Modes.sample_rate,
+                                     MODES_SAMPLE_RATE,
                                      Modes.dc_filter,
                                      &ifile.converter_state);
     if (!ifile.converter) {
@@ -210,14 +207,14 @@ void ifileRun()
         pthread_mutex_unlock(&Modes.data_mutex);
 
         // Compute the sample timestamp for the start of the block
-        outbuf->sampleTimestamp = sampleCounter * 12e6 / Modes.sample_rate;
+        outbuf->sampleTimestamp = sampleCounter * 12e6 / MODES_SAMPLE_RATE;
         sampleCounter += MODES_MAG_BUF_SAMPLES;
 
         // Copy trailing data from last block (or reset if not valid)
         if (lastbuf->length >= Modes.trailing_samples) {
-            memcpy(outbuf->data, lastbuf->data + lastbuf->length, Modes.trailing_samples * sizeof(uint16_t));
+            memcpy(outbuf->data, lastbuf->data + lastbuf->length, Modes.trailing_samples * sizeof(mag_data_t));
         } else {
-            memset(outbuf->data, 0, Modes.trailing_samples * sizeof(uint16_t));
+            memset(outbuf->data, 0, Modes.trailing_samples * sizeof(mag_data_t));
         }
 
         // Get the system time for the start of this block
@@ -253,7 +250,7 @@ void ifileRun()
                 ;
 
             // compute the time we can deliver the next buffer.
-            next_buffer_delivery.tv_nsec += outbuf->length * 1e9 / Modes.sample_rate;
+            next_buffer_delivery.tv_nsec += outbuf->length * 1e9 / MODES_SAMPLE_RATE;
             normalize_timespec(&next_buffer_delivery);
         }
 

--- a/sdr_rtlsdr.c
+++ b/sdr_rtlsdr.c
@@ -145,6 +145,7 @@ void rtlsdrShowHelp()
     printf("--enable-agc             enable digital AGC (not tuner AGC!)\n");
     printf("--ppm <correction>       set oscillator frequency correction in PPM\n");
     printf("--direct <0|1|2>         set direct sampling mode\n");
+
     printf("\n");
 }
 
@@ -248,12 +249,12 @@ bool rtlsdrOpen(void) {
 
     rtlsdr_set_freq_correction(RTLSDR.dev, RTLSDR.ppm_error);
     rtlsdr_set_center_freq(RTLSDR.dev, Modes.freq);
-    rtlsdr_set_sample_rate(RTLSDR.dev, (unsigned)Modes.sample_rate);
+    rtlsdr_set_sample_rate(RTLSDR.dev, MODES_SAMPLE_RATE);
 
     rtlsdr_reset_buffer(RTLSDR.dev);
 
     RTLSDR.converter = init_converter(INPUT_UC8,
-                                      Modes.sample_rate,
+                                      MODES_SAMPLE_RATE,
                                       Modes.dc_filter,
                                       &RTLSDR.converter_state);
     if (!RTLSDR.converter) {
@@ -321,18 +322,18 @@ void rtlsdrCallback(unsigned char *buf, uint32_t len, void *ctx) {
     pthread_mutex_unlock(&Modes.data_mutex);
 
     // Compute the sample timestamp and system timestamp for the start of the block
-    outbuf->sampleTimestamp = sampleCounter * 12e6 / Modes.sample_rate;
+    outbuf->sampleTimestamp = sampleCounter * 12e6 / MODES_SAMPLE_RATE;
     sampleCounter += slen;
 
     // Get the approx system time for the start of this block
-    block_duration = 1e3 * slen / Modes.sample_rate;
+    block_duration = 1e3 * slen / MODES_SAMPLE_RATE;
     outbuf->sysTimestamp = mstime() - block_duration;
 
     // Copy trailing data from last block (or reset if not valid)
     if (outbuf->dropped == 0) {
-        memcpy(outbuf->data, lastbuf->data + lastbuf->length, Modes.trailing_samples * sizeof(uint16_t));
+        memcpy(outbuf->data, lastbuf->data + lastbuf->length, Modes.trailing_samples * sizeof(mag_data_t));
     } else {
-        memset(outbuf->data, 0, Modes.trailing_samples * sizeof(uint16_t));
+        memset(outbuf->data, 0, Modes.trailing_samples * sizeof(mag_data_t));
     }
 
     // Convert the new data

--- a/sdr_rtlsdr.c
+++ b/sdr_rtlsdr.c
@@ -333,7 +333,9 @@ void rtlsdrCallback(unsigned char *buf, uint32_t len, void *ctx) {
     if (outbuf->dropped == 0) {
         memcpy(outbuf->data, lastbuf->data + lastbuf->length, Modes.trailing_samples * sizeof(mag_data_t));
     } else {
-        memset(outbuf->data, 0, Modes.trailing_samples * sizeof(mag_data_t));
+        for (int i = 0; i < Modes.trailing_samples; ++i) {
+            outbuf->data[i] = 0.0;
+        }
     }
 
     // Convert the new data

--- a/stats.h
+++ b/stats.h
@@ -72,15 +72,15 @@ struct stats {
     struct timespec background_cpu;
 
     // noise floor:
-    double noise_power_sum;
+    internal_float_t noise_power_sum;
     uint64_t noise_power_count;
 
     // mean signal power:
-    double signal_power_sum;
+    internal_float_t signal_power_sum;
     uint64_t signal_power_count;
 
     // peak signal power seen
-    double peak_signal_power;
+    internal_float_t peak_signal_power;
 
     // number of signals with power > -3dBFS
     uint32_t strong_signal_count;


### PR DESCRIPTION
Increasing the precision and dynamic range of internal math by storing sample magnitude data as floats, doing internal calculations on doubles, fixing some sketchy uint8 to floating point conversions (see d891e05), and reducing the number of conversions between floats and ints. Reason is to support more advanced SDRs with sample depths of 16 bits or more (see AirSpy HF+) and increase precision by avoiding so much rounding while converting between floats adn ints and the precision of internal calculations. Seems to be a wash on CPU performance based on my testing with a mac and rbpi and may very have increased message rates even with a RTL-SDR. 

Also remove some unneeded defines and values like Modes.sample_rate since the whole rest of the code only supports 2.4 MHz, if you want a higher sample rate, you could set it on the hardware and resample or decimate it. Should be enough since these signals only have bandwidth of 1MHz, but resampling a higher rate down could still increase precision.

LimeSDR support is broken though, not sure why I just get a mysterious bus error that I never saw before, but it's also in the develop branch and the original limesdr_support branch that I had working, so I blame Apple.